### PR TITLE
Scene "pushin-from" attribute value not being registered after code refactor

### DIFF
--- a/docs/home.pug
+++ b/docs/home.pug
@@ -75,8 +75,8 @@ block content
 							a(href='responsive.html') Responsive design
 		main
 			section.pushin.bg-secondary.bg-opacity-25(style="z-index:-1")
-				div.pushin-scene
-					div.pushin-layer(data-pushin-from='200', data-pushin-to='1000')
+				div.pushin-scene(data-pushin-from='200')
+					div.pushin-layer(data-pushin-to='1000')
 						div.card.bg-info.bg-gradient.shadow-lg.position-absolute.demo-card-1
 							div.card-body.fs-1.fw-bold.p-5 Scroll to push in
 					div.pushin-layer(data-pushin-from='700', data-pushin-to='2500')

--- a/src/pushin.js
+++ b/src/pushin.js
@@ -121,8 +121,8 @@ class pushIn {
       inpoints = inpoints.map((inpoint) => parseInt(inpoint.trim()));
     } else if (i === 0 && this.scene.dataset.hasOwnProperty('pushinFrom')) {
       // custom inpoint
-      sceneInpoints = this.scene.dataset.pushinFrom.split(',');
-      sceneInpoints = sceneInpoints.map((inpoint) => parseInt(inpoint.trim()));
+      inpoints = this.scene.dataset.pushinFrom.split(',');
+      inpoints = inpoints.map((inpoint) => parseInt(inpoint.trim()));
     } else if (i > 0) {
       // Set default for middle layers if none provided
       const { outpoint } = this.layers[i - 1].params;

--- a/test/getInpoints.js
+++ b/test/getInpoints.js
@@ -54,6 +54,15 @@ describe( 'getInpoints', function() {
     } );
 
     it( 'Should return scene top value as the default for first layer', function() {
+        const scene  = document.querySelector( '.pushin-scene' );
+        scene.setAttribute( 'data-pushin-from', '30' );
+
+        const elem   = document.querySelector( '#layer-0' );
+        const result = this.pushIn.getInpoints( elem, 0 );
+        result.should.deep.equal( [ 30 ] );
+    } );
+
+    it( 'Should return scene[pushinFrom] value, if available for first layer', function() {
         const elem   = document.querySelector( '#layer-0' );
         const result = this.pushIn.getInpoints( elem, 0 );
         result.should.deep.equal( [ 10 ] );


### PR DESCRIPTION
Referenced in issue #66

Some code was refactored but a variable was not renamed. There was also a missing use case in the unit tests, so as a result there was some broken functionality if trying to set  the `data-pushin-from` attribute at the `pushin-scene` level.